### PR TITLE
update read_repo to use pattern and implement n_max

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yawp
 Type: Package
 Title: Yet Another Working Package
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("VP", "Nagraj", role = c("aut", "cre"), email = "nagraj@nagraj.net"))
 Maintainer: VP Nagraj <nagraj@nagraj.net>
 Description: Home to miscellanea. Functions included are generic helpers for data manipulation, visualization, and analysis. 
@@ -21,7 +21,7 @@ Imports:
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 RdMacros: lifecycle
 Suggests: 
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,4 @@
+# yawp 0.1.1
+
+* Added `n_files` argument to `read_repo()`
+* Fixed `pattern=` argument usage in `read_repo()`

--- a/R/vis.R
+++ b/R/vis.R
@@ -124,7 +124,7 @@ theme_mathbook <- function() {
                  legend.title = ggplot2::element_blank(),
                  text = ggplot2::element_text(color = "white"),
                  axis.text = ggplot2::element_text(color = "white"),
-                 strip.background = element_rect(fill="white"),
+                 strip.background = ggplot2::element_rect(fill="white"),
                  legend.position = "bottom")
 
 }

--- a/man/read_repo.Rd
+++ b/man/read_repo.Rd
@@ -10,6 +10,7 @@ read_repo(
   pattern = NULL,
   to_tibble = FALSE,
   .f = readr::read_csv,
+  n_files = NULL,
   ...
 )
 }
@@ -23,6 +24,8 @@ read_repo(
 \item{to_tibble}{Boolean indicating whether or not the function should attempt to return a \code{tibble}; default is \code{FALSE}}
 
 \item{.f}{Function to read each file whose name complies to \code{pattern} argument in the repository; default is \link[readr]{read_csv}}
+
+\item{n_files}{Maximum number of files to read in}
 
 \item{...}{Additional arguments passed to the \code{.f} read function}
 }
@@ -38,4 +41,16 @@ This utility allows files from a GitHub repository to be read in bulk. The patte
 Starting with a call to the GitHub API, this function returns a list of files, which are then filtered to include only those that match the regular expression in the "pattern" argument. The function then internally constructs the raw content URLs and then applies the read function (".f") to each path.
 
 \strong{NOTE}: The API call is unauthenticated. GitHub API request rate limits apply. For specifics, review the GitHub API documentation.
+}
+\examples{
+\dontrun{
+read_repo(repo = "cdcepi/Flusight-forecast-data",
+          branch = "master",
+          pattern = "data-forecasts/.*/.*\\\\.csv",
+          to_tibble = TRUE,
+          .f = readr::read_csv,
+          n_files=10,
+          col_types="DcDccdd",
+          progress=FALSE)
+}
 }


### PR DESCRIPTION
- e8ace35b957bdf82ec5447325443d7c155c2eca3
    - adds an `n_files` argument that limits the number of files read in by `read_repo`
    - I'm not sure the `pattern` argument was actually being used? Check me on this.
    - added a (dontrun) example
- 21500255cd1eb9075da58ef02ec0423ab69352e5 silence a cran note explicitly call `ggplot2::element_rect`
- 3cb1352bee3391445ba8d02caea22487b40e7b74 bump version & NEWS.md