### PR TITLE
name repo files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yawp
 Type: Package
 Title: Yet Another Working Package
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("VP", "Nagraj", role = c("aut", "cre"), email = "nagraj@nagraj.net"))
 Maintainer: VP Nagraj <nagraj@nagraj.net>
 Description: Home to miscellanea. Functions included are generic helpers for data manipulation, visualization, and analysis. 
@@ -21,7 +21,7 @@ Imports:
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 RdMacros: lifecycle
 Suggests: 
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# yawp 0.1.2
+
+* Get `names()` of files read in by `read_repo()` to make it possible to return filenames in output tibble.
+
 # yawp 0.1.1
 
 * Added `n_files` argument to `read_repo()`

--- a/R/read.R
+++ b/R/read.R
@@ -31,7 +31,8 @@
 #'           .f = readr::read_csv,
 #'           n_files=10,
 #'           col_types="DcDccdd",
-#'           progress=FALSE)
+#'           progress=FALSE,
+#'           .id="forecast_filename")
 #' }
 #' @export
 #'
@@ -59,6 +60,9 @@ read_repo <- function(repo, branch = "master", pattern = NULL, to_tibble = FALSE
   if(!is.null(pattern)) {
     repo_files <- repo_files[grepl(pattern, repo_files)]
   }
+
+  ## Set names
+  names(repo_files) <- basename(repo_files)
 
   ## Limit the number of files
   if (!is.null(n_files) && is.numeric(n_files)) {

--- a/man/read_repo.Rd
+++ b/man/read_repo.Rd
@@ -51,6 +51,7 @@ read_repo(repo = "cdcepi/Flusight-forecast-data",
           .f = readr::read_csv,
           n_files=10,
           col_types="DcDccdd",
-          progress=FALSE)
+          progress=FALSE,
+          .id="forecast_filename")
 }
 }


### PR DESCRIPTION
fixes #3 

Before:

``` r
yawp::read_repo(repo = "cdcepi/Flusight-forecast-data",
                branch = "master",
                pattern = "data-forecasts/.*/.*\\.csv",
                to_tibble = TRUE,
                .f = readr::read_csv,
                n_files=2,
                col_types="DcDccdd",
                progress=FALSE)
#> # A tibble: 192 × 7
#>    forecast_date target                  target_en…¹ locat…² type  quant…³ value
#>    <date>        <chr>                   <date>      <chr>   <chr>   <dbl> <dbl>
#>  1 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      point  NA     221. 
#>  2 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.01   81.6
#>  3 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.025  83.7
#>  4 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.05  108. 
#>  5 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.1   148. 
#>  6 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.15  179. 
#>  7 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.2   189. 
#>  8 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.25  200. 
#>  9 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.3   209. 
#> 10 2022-10-17    1 wk ahead inc flu hosp 2022-10-22  06      quan…   0.35  212. 
#> # … with 182 more rows, and abbreviated variable names ¹​target_end_date,
#> #   ²​location, ³​quantile
```

<sup>Created on 2022-11-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

After:

``` r
yawp::read_repo(repo = "cdcepi/Flusight-forecast-data",
                branch = "master",
                pattern = "data-forecasts/.*/.*\\.csv",
                to_tibble = TRUE,
                .f = readr::read_csv,
                n_files=2,
                col_types="DcDccdd",
                progress=FALSE, 
                .id="forecast_filename")
#> # A tibble: 192 × 8
#>    forecast_filename    forecast…¹ target target_e…² locat…³ type  quant…⁴ value
#>    <chr>                <date>     <chr>  <date>     <chr>   <chr>   <dbl> <dbl>
#>  1 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      point  NA     221. 
#>  2 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.01   81.6
#>  3 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.025  83.7
#>  4 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.05  108. 
#>  5 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.1   148. 
#>  6 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.15  179. 
#>  7 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.2   189. 
#>  8 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.25  200. 
#>  9 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.3   209. 
#> 10 2022-10-17-CADPH-Fl… 2022-10-17 1 wk … 2022-10-22 06      quan…   0.35  212. 
#> # … with 182 more rows, and abbreviated variable names ¹​forecast_date,
#> #   ²​target_end_date, ³​location, ⁴​quantile
```

<sup>Created on 2022-11-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

No errors/warnings. Did get a NOTE:

```
❯ checking dependencies in R code ... NOTE
  Namespaces in Imports field not imported from:
    ‘lifecycle’ ‘patchwork’ ‘readr’
    All declared Imports should be used.
```