### PR TITLE
Add comprehensive tests for utilities

### DIFF
--- a/tests/testthat/test-more-and-vis.R
+++ b/tests/testthat/test-more-and-vis.R
@@ -1,0 +1,38 @@
+context("Additional utilities")
+
+test_that("more appends filler rows correctly", {
+  input <- tibble::tibble(a = c("x","y"), b = c("z","w"))
+  res <- more(input, fill = "-", extra_rows = 2)
+  expect_s3_class(res, "tbl_df")
+  expect_equal(nrow(res), 4)
+  expect_true(all(res[3:4,] == "-"))
+})
+
+test_that("mav computes moving averages", {
+  x <- 1:10
+  expect_equal(mav(x, window = 3, align = "center"),
+               c(NA,2:9,NA))
+  expect_equal(mav(x, window = 3, align = "left"),
+               c(NA,NA,2:9))
+})
+
+test_that("mav returns numeric vector for ts input", {
+  x <- ts(1:4)
+  res <- mav(x, window = 2, align = "left")
+  expect_type(res, "double")
+})
+
+test_that("theme_mathbook customizations", {
+  th <- theme_mathbook()
+  expect_equal(th$plot.background$fill, "black")
+  expect_equal(th$text$colour, "white")
+  expect_equal(th$legend.position, "bottom")
+})
+
+test_that("gg_zoom returns patchwork object", {
+  dat <- tibble::tibble(x = 1:5, y = 1:5, lbl = letters[1:5])
+  p <- ggplot2::ggplot(dat, ggplot2::aes(x,y)) + ggplot2::geom_point()
+  res <- gg_zoom(p, x > 3, to_label = TRUE, label = lbl, draw_box = FALSE)
+  expect_true(yawp:::is_patchwork(res))
+})
+

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -51,3 +51,27 @@ test_that("f1 score is correct for use_thresh = FALSE", {
   expect_equal(round(tst,3), 0.849)
 
 })
+
+test_that("f1 errors when positive value is 0", {
+  dat <- data.frame(obs = c(1,0,1), truth = c(1,1,0))
+  expect_error(f1(dat, observed = obs, truth = truth, positive = "0"))
+})
+
+test_that("f1 errors when there are no matching values", {
+  dat <- data.frame(obs = c("A","A"), truth = c("B","B"))
+  expect_error(f1(dat, observed = obs, truth = truth, positive = "A"))
+})
+
+test_that("f1 calculates correctly with thresholds", {
+  dat <- tibble::tibble(prob = c(0.1,0.4,0.6,0.9),
+                        truth = c("0","0","1","1"))
+  res <- f1(dat, observed = prob, truth = truth,
+            positive = "1", use_thresh = TRUE,
+            thresh = c(0.5, 0.7))
+  expect_equal(res$f1, c(1, 2*((1*0.5)/(1+0.5))))
+})
+
+test_that("propf handles NA levels and percent = FALSE", {
+  x <- c("a","b",NA,"a")
+  expect_equal(propf(x, level = NA, percent = FALSE), "1 (0.25)")
+})


### PR DESCRIPTION
## Summary
- add tests for more data manipulation utilities
- extend stats tests with error paths and threshold cases
- test visualization helpers including `gg_zoom`

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*